### PR TITLE
Support firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bundled-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+bundled-sw.js: sw.js spa.js idb.js
+	esbuild --bundle $< --format=iife --platform=browser --outfile=$@

--- a/index.html
+++ b/index.html
@@ -8,9 +8,8 @@
     <script type="module">
       async function load() {
         try {
-          const registration = await navigator.serviceWorker.register("/sw.js", {
+          const registration = await navigator.serviceWorker.register("/bundled-sw.js", {
             scope: "/",
-            type: "module",
           });
           if (registration.active) return;
 

--- a/spa.js
+++ b/spa.js
@@ -56,7 +56,9 @@ export default class SPA {
 
       let body = {};
       try {
-        if (request.body) body = await readableStreamToJSON(request.body);
+        body = request.body
+          ? await readableStreamToJSON(request.body)
+          : Object.fromEntries(await request.formData());
       } catch (err) {
         console.warn("Couldn't parse request body as JSON", err);
       }


### PR DESCRIPTION
After your toot I had a look at what it would take to fix this in Firefox.
This is what was unsupported:
- [Module Service Workers](https://caniuse.com/mdn-api_serviceworker_ecmascript_modules)
- [`Request.body`](https://caniuse.com/mdn-api_request_body)

<sub>(no expectation you merge this, I was just curious what it'd take)</sub>